### PR TITLE
update #not-editor element background

### DIFF
--- a/light-soda.css
+++ b/light-soda.css
@@ -124,7 +124,7 @@
     -webkit-box-orient: vertical;
     -webkit-box-pack: center;
     -webkit-box-align: center;
-    background: rgba(51, 51, 51, 0) url('file://localhost/Applications/Brackets%20Sprint%2027.app/Contents/www/styles/images/no_content_bg.svg') no-repeat center 45%;
+    background-color: rgba(51, 51, 51, 0);
    /* opacity: .07;*/
 }
 
@@ -142,7 +142,7 @@
     -webkit-box-align: center;
     -moz-box-align: center;
     box-align: center;
-    background: #242424;
+    background-color: #242424;
 
 }
 


### PR DESCRIPTION
the background-image url(file://localhost/Applications/Brackets%20Sprint%2027.app/Contents/www/styles/images/no_content_bg.svg) is invalid in win and linux
